### PR TITLE
Added caching to collatz solution

### DIFF
--- a/SD-spring-2024/Collatz-Sequence/CollatzSequence.cs
+++ b/SD-spring-2024/Collatz-Sequence/CollatzSequence.cs
@@ -16,8 +16,12 @@
     static long longestChain = 0;
     static long count = 1;
 
+    
+    static Dictionary<long,long> cache = new Dictionary<long, long>();
+
 	public static (long, long) DetermineAnswer()
     {
+        cache.Add(1,1);
         for (int i = 1; i < 1_000_000; i++)
         {
             count = 1;
@@ -33,18 +37,25 @@
 		
     static void RunSequence(long number)
     {
+        if(cache.ContainsKey(number)) {
+            count = cache[number];
+            return;
+        }
         if (number == 1) { return; }
         else if (number % 2 == 0)
         {
-            number = number / 2;
+            var nextnumber = number / 2;
+            RunSequence(nextnumber);
             count++;
-            RunSequence(number);
+            
         }
         else
         {
-            number = (number * 3) + 1;
+            var nextnumber = (number * 3) + 1;
+            RunSequence(nextnumber);
             count++;
-            RunSequence(number);
+
         }
+        cache.TryAdd(number,count);
     }
 }

--- a/SD-spring-2024/Program.cs
+++ b/SD-spring-2024/Program.cs
@@ -18,6 +18,11 @@ void AnswerCollatzQuestion()
     Console.WriteLine($"The number with the longest chain is {answer.Number} with {answer.Terms} terms.");
 }
 
-// AnswerCollatzQuestion();
+var watch = System.Diagnostics.Stopwatch.StartNew();
+ AnswerCollatzQuestion();
+watch.Stop();
+var elapsedMs = watch.ElapsedMilliseconds;
+Console.WriteLine($"Took {elapsedMs} ms");
+
 
 // SumDifferenceSolution.SolveSumDifferenceProblem();


### PR DESCRIPTION
Added a dictionary to store intermediate values so we don't recalculate for each value.

In my test, sped up calculation for 1M from 1.5 seconds to ~250ms; and should speed up larger values even more.